### PR TITLE
fix no such directory bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import web
 import time
+import os
 
 from pygments import highlight
 from pygments.formatters.html import HtmlFormatter
@@ -47,6 +48,8 @@ class index:
     def POST(self):
         form = web.input()
         file_id = (int)(time.time())
+        if not os.path.exists("./data/"):
+            os.makedirs("./data/")
         with open("./data/"+str(file_id), 'w', newline='') as f:
             f.write(form.content)
         raise web.seeother('/p/' + str(file_id) + '?type=' + form.type + '&suffix=' + form.suffix)


### PR DESCRIPTION
In a clean clone of the repo, there is no `./data/` directory, and `open()` method throws an error since the directory does not exist:

```
<class 'FileNotFoundError'> at /
[Errno 2] No such file or directory: './data/1628130853'
Python	D:\gitrepos\codePaste\main.py in POST, line 49
Web	POST http://localhost:8080/
```